### PR TITLE
Use major versions for workflows

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -11,10 +11,10 @@ jobs:
       id-token: write  # mandatory for PyPI trusted publishing
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.11"
           architecture: x64
@@ -25,7 +25,7 @@ jobs:
           python -m build sdist wheel
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.6
+        uses: pypa/gh-action-pypi-publish@release/v1.8
         # dont specify anything for Trusted Publishing
         # https://docs.pypi.org/trusted-publishers
         # with:

--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.11"
           architecture: x64

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64


### PR DESCRIPTION
Most of the workflows we use maintain a tag for the major version in addition to the fully qualified version

Ex: v4 and v4.3.2 are both tags for the same commit. It's handy to keep the workflow updated to the __latest compatible version__ without having to setup dependabot.