### PR TITLE
Enhance CI regarding docker and python build

### DIFF
--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -16,8 +16,7 @@ jobs:
         uses: openzim/docker-publish-action@v10
         with:
           image-name: openzim/great-project
-          on-master: dev
-          tag-pattern: /^v([0-9.]+)$/
+          manual-tag: dev
           latest-on-tag: false
           restrict-to: openzim/_python-bootstrap
           registries: ghcr.io

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Ensure we can build the Docker image
         run: |
-          docker build -t ghcr.io/library/testimage .
+          docker build -t testimage .
 
       - name: Ensure we can start the Docker image
         run: |
-          docker run --rm ghcr.io/library/testimage
+          docker run --rm testimage


### PR DESCRIPTION
Fix #23 

Changes:
- test the build of the Docker image and its startup
- separate the python build in a dedicated job since it can run in parallel
- build and publish a Docker image tagged `dev` for every push on main branch