### PR TITLE
Adopt hatch-openzim plugin and upgrade dependencies

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python: ["3.10", "3.11"]
+        python: ["3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: inv coverage --args "-vvv"
 
       - name: Upload coverage report to codecov
-        if: matrix.python == '3.11'
+        if: matrix.python == '3.12'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,20 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   -   id: trailing-whitespace
   -   id: end-of-file-fixer
 - repo: https://github.com/psf/black
-  rev: "23.7.0"
+  rev: "24.1.1"
   hooks:
   -   id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.282
+  rev: v0.2.0
   hooks:
   - id: ruff
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.320
+  rev: v1.1.349
   hooks:
   - id: pyright
     name: pyright (system)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,19 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-openzim"]
 build-backend = "hatchling.build"
 
 [project]
 name = "great-project"
-authors = [
-  { name = "Kiwix", email = "dev@kiwix.org" },
-]
-keywords = ["some"]
-requires-python = ">=3.10"
+requires-python = ">=3.12,<3.13"
 description = "A Great Project"
 readme = "README.md"
-license = {text = "GPL-3.0-or-later"}
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-]
 dependencies = [
     "requests==2.31.0",
 ]
-dynamic = ["version"]
+dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
+
+[tool.hatch.metadata.hooks.openzim-metadata]
+additional-keywords = ["some"]
 
 [project.optional-dependencies]
 scripts = [
@@ -45,10 +38,6 @@ dev = [
   "great-project[test]",
   "great-project[check]",
 ]
-
-[project.urls]
-Homepage = "https://github.com/openzim/great-project"
-Donate = "https://www.kiwix.org/en/support-us/"
 
 [project.scripts]
 great-binary = "great_project:entrypoint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "great-project"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.11,<3.13"
 description = "A Great Project"
 readme = "README.md"
 dependencies = [
@@ -20,19 +20,19 @@ scripts = [
   "invoke==2.2.0",
 ]
 lint = [
-  "black==23.7.0",
-  "ruff==0.0.282",
+  "black==24.1.1",
+  "ruff==0.2.0",
 ]
 check = [
-  "pyright==1.1.320",
+  "pyright==1.1.349",
 ]
 test = [
-  "pytest==7.4.0",
-  "coverage==7.2.7",
+  "pytest==8.0.0",
+  "coverage==7.4.1",
 ]
 dev = [
-  "pre-commit==3.3.3",
-  "debugpy==1.6.7",
+  "pre-commit==3.6.0",
+  "debugpy==1.8.0",
   "great-project[scripts]",
   "great-project[lint]",
   "great-project[test]",
@@ -97,6 +97,8 @@ target-version = ['py310']
 target-version = "py311"
 line-length = 88
 src = ["src"]
+
+[tool.ruff.lint]
 select = [
   "A",  # flake8-builtins
   # "ANN",  # flake8-annotations
@@ -173,17 +175,17 @@ unfixable = [
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["great_project"]
 
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 # add exceptions to B008 for fastapi.
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,5 +13,5 @@ def test_version():
 def test_compute():
     assert compute(1, 2) == 3
     with pytest.raises(TypeError):
-        compute(1.0, 2)  # pyright: ignore [reportGeneralTypeIssues]
+        compute(1.0, 2)  # pyright: ignore [reportArgumentType]
     assert entrypoint() is None


### PR DESCRIPTION
## Changes

- Adopt hatch-openzim for metadata computation
- Upgrade dependencies
- Upgrade to Python 3.11 + 3.12 (instead of 3.10 + 3.11)
- Fix ruff configuration in `pyproject.toml` to fix depreciation warning in `0.2`
- Fix Pyright ignore rules to adapt to breaking changes in 1.1.348