### PR TITLE
Fix coverage upload

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -35,6 +35,7 @@ jobs:
         if: matrix.python == '3.12'
         uses: codecov/codecov-action@v3
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build_python:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tests workflow now fails CI if the codecov upload step fails
+
 ### Fixed
 
 - Coverage invoke task now generating coverage.xml which codecov will upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Coverage invoke task now generating coverage.xml which codecov will upload
+
 ## [1.0.1] - 2024-04-19
 
 ### Fixed
@@ -81,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Adjust Ruff rules ignored by default
-- Use `no-cache-dir` for package install 
+- Use `no-cache-dir` for package install
 
 ## [0.1.4] - 2023-07-17
 

--- a/tasks.py
+++ b/tasks.py
@@ -24,6 +24,7 @@ def report_cov(ctx: Context, *, html: bool = False):
     """report coverage"""
     ctx.run("coverage combine", warn=True, pty=use_pty)
     ctx.run("coverage report --show-missing", pty=use_pty)
+    ctx.run("coverage xml", pty=use_pty)
     if html:
         ctx.run("coverage html", pty=use_pty)
 


### PR DESCRIPTION
Usage of `coverage` stores data in the internal `.coverage` file that is not supported^1 by codecov.
This results in silently (because we dont use fail option by default) not uploading coverage.

This fixes it by runnin `coverage xml` in coverage_report which outputs a compatible file in `coverage.xml`

1: https://docs.codecov.com/docs/supported-report-formats#non-supported-code-coverage-formats