### PR TITLE
Upgrade versions of dependencies, Python, CI actions and VM

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write  # mandatory for PyPI trusted publishing
 

--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -11,10 +11,10 @@ jobs:
       id-token: write  # mandatory for PyPI trusted publishing
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
           architecture: x64

--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build and push Docker image
         uses: openzim/docker-publish-action@v10

--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-qa:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
           architecture: x64

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -10,7 +10,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         python: ["3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
@@ -39,7 +39,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build_python:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -55,7 +55,7 @@ jobs:
           python3 -m build --sdist --wheel
 
   build_docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload coverage report to codecov
         if: matrix.python == '3.12'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -41,10 +41,10 @@ jobs:
   build_python:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
           architecture: x64
@@ -57,7 +57,7 @@ jobs:
   build_docker:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Ensure we can build the Docker image
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,15 @@ repos:
   -   id: trailing-whitespace
   -   id: end-of-file-fixer
 - repo: https://github.com/psf/black
-  rev: "24.1.1"
+  rev: "24.4.2"
   hooks:
   -   id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.0
+  rev: v0.5.1
   hooks:
   - id: ruff
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.349
+  rev: v1.1.370
   hooks:
   - id: pyright
     name: pyright (system)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade CI to use ubuntu-24.04
 - Upgrade CI actions to use latest version
 
+## Fixed
+
+- Fixed `pyproject.toml` versions used in pytest, black, ruff and pyright
+
 ## [1.0.2] - 2024-06-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade CI to use ubuntu-24.04
+
 ## [1.0.2] - 2024-06-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade CI to use ubuntu-24.04
+- Upgrade CI actions to use latest version
 
 ## [1.0.2] - 2024-06-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,19 +20,19 @@ scripts = [
   "invoke==2.2.0",
 ]
 lint = [
-  "black==24.1.1",
-  "ruff==0.2.0",
+  "black==24.4.2",
+  "ruff==0.5.1",
 ]
 check = [
-  "pyright==1.1.349",
+  "pyright==1.1.370",
 ]
 test = [
-  "pytest==8.0.0",
-  "coverage==7.4.1",
+  "pytest==8.2.2",
+  "coverage==7.5.4",
 ]
 dev = [
-  "pre-commit==3.6.0",
-  "debugpy==1.8.0",
+  "pre-commit==3.7.1",
+  "debugpy==1.8.2",
   "great-project[scripts]",
   "great-project[lint]",
   "great-project[test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ features = ["dev"]
 features = ["scripts", "test"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 run = "inv test --args '{args}'"
@@ -91,10 +91,10 @@ all = "inv checkall --args '{args}'"
 
 [tool.black]
 line-length = 88
-target-version = ['py310']
+target-version = ['py311']
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 88
 src = ["src"]
 
@@ -217,6 +217,6 @@ exclude_lines = [
 include = ["src", "tests", "tasks.py"]
 exclude = [".env/**", ".venv/**"]
 extraPaths = ["src"]
-pythonVersion = "3.11"
+pythonVersion = "3.12"
 typeCheckingMode="strict"
 disableBytesTypePromotions = true


### PR DESCRIPTION
Changes:
- Upgrade CI to use ubuntu-24.04
- Upgrade CI actions to use latest version
- Fixed `pyproject.toml` versions used in pytest, black, ruff and pyright
- Update Python dependencies