### PR TITLE
Updated Dockerfile base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade Docker image to use python:3.12-slim-bookworm
+
 ## [1.0.3] - 2024-07-08
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm
 LABEL org.opencontainers.image.source https://github.com/openzim/_python-bootstrap
 
 # Install necessary packages


### PR DESCRIPTION
Updating base image as requested in https://github.com/openzim/devdocs/pull/2 to match the other changes in the v1.0.3 release.