### PR TITLE
Add Docker badge in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade Docker image to use python:3.12-slim-bookworm
+- Add Docker badge
 
 ## [1.0.3] - 2024-07-08
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Leverages great things to achieve great results
 [![codecov](https://codecov.io/gh/openzim/_python-bootstrap/branch/main/graph/badge.svg)](https://codecov.io/gh/openzim/_python-bootstrap)
 [![PyPI version shields.io](https://img.shields.io/pypi/v/great_project.svg)](https://pypi.org/project/great_project/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/great_project.svg)](https://pypi.org/project/great_project)
+[![Docker](https://ghcr-badge.egpl.dev/openzim/_python-bootstrap/latest_tag?label=docker)](https://ghcr.io/openzim/_python-bootstrap)
 
 ## Usage
 


### PR DESCRIPTION
I propose to add by default a Docker badge, it is easy to remove if it makes no sense for a particular repo.