### PR TITLE
remove black as dev dependency and upgrade ruff

### DIFF
--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -22,13 +22,13 @@ jobs:
       - name: Install dependencies (and project)
         run: |
           pip install -U pip
-          pip install -e .[lint,scripts,test,check]
+          pip install -e .[qa,scripts,test]
 
-      - name: Check black formatting
-        run: inv lint-black
+      - name: Check Linting
+        run: inv check-lint
 
-      - name: Check ruff
-        run: inv lint-ruff
+      - name: Check Formatting
+        run: inv check-format
 
-      - name: Check pyright
-        run: inv check-pyright
+      - name: Check Type
+        run: inv check-type

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,13 @@ repos:
   hooks:
   -   id: trailing-whitespace
   -   id: end-of-file-fixer
-- repo: https://github.com/psf/black
-  rev: "24.4.2"
-  hooks:
-  -   id: black
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.1
+  rev: v0.15.12
   hooks:
-  - id: ruff
+    - id: ruff-check
+    - id: ruff-format
+
 - repo: https://github.com/RobertCraigie/pyright-python
   rev: v1.1.370
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `black` from `pyproject.toml` and `tasks.py`
+- Upgrade `ruff` to `0.15.12`
+- Merge `check` and `lint` features into `qa`
+- Remove `lint-black`, `lint-ruff`, `fix-black`, `fix-ruff`, `lintall`, `fixall`, and
+  `check-pyright` invoke tasks
+- Add new invoke tasks: `check-lint`, `check-format`, `check-type`, `check-all`,
+  `fix-format`, `fix-lint` and `fix-all`
+
 ### Changed
 
 - Upgrade Docker image to use python:3.12-slim-bookworm
@@ -86,7 +94,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix few invoke task arguments and help
 
-
 ## [0.1.7] - 2023-08-04
 
 ### Changed
@@ -141,8 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the scripts to lint's features, otherwise we can use the hatch run lint:*
-
+- Add the scripts to lint's features, otherwise we can use the hatch run lint:\*
 
 ## [0.1.0] - 2023-06-22
 

--- a/docs/Developer-Setup.md
+++ b/docs/Developer-Setup.md
@@ -49,7 +49,6 @@ The key part is the symlink to `.venv` so that LSP-pyright and other tool can au
 - When doing some JS, you obviously need a Node.JS as well 
 - [hatch](https://pypi.org/project/hatch/) installed globally
 - [Visual Studio Code](https://github.com/microsoft/vscode) with following extensions (more or less related to Python development)
-  - Black Formater (Microsoft)
   - Dev Containers (Microsoft)
   - Docker (Microsoft)
   - Excalidraw (pomdtr)
@@ -77,12 +76,6 @@ This additional Hatch config section ensures that all virtual environments (the 
 On every project, create a local `.vscode/settings.json` to automatically format your code (adjust `typeCheckingMode` depending on your project):
 ``` json
 {
-  "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter",
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
-    }
-  },
   "python.analysis.typeCheckingMode": "strict",
   "eslint.validate": ["javascript", "typescript", "vue"],
   "eslint.workingDirectories": [{ "mode": "auto" }],

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -13,14 +13,12 @@ If you've not already read it, please check our [Policy](./Policy.md) first.
 ❯ hatch env show
 
 # linting, testing, coverage, checking
-❯ hatch run lint:all
-❯ hatch run lint:fixall
+❯ hatch run qa:check-all
+❯ hatch run qa:fix-all
 # run tests on all matrixed' envs
 ❯ hatch run test:run
 # run tests in a single matrixed' env
 ❯ hatch env run -e test -i py=3.11 coverage
-# run static type checks
-❯ hatch env run check:all
 
 # building packages
 ❯ hatch build
@@ -38,12 +36,13 @@ If you've not already read it, please check our [Policy](./Policy.md) first.
 # scripts discovery
 ❯ inv -l
 
-# linting, testing, coverage, static type checks
-❯ inv lintall
-❯ inv fixall
+# check linting, formatting and static type checks
+❯ inv check-all
+# fix everything automatically
+❯ inv fix-all
+# run tests
 ❯ inv test
 ❯ inv coverage
-❯ inv checkall
 
 # building packages
 ❯ pip install build

--- a/docs/pyproject.toml.md
+++ b/docs/pyproject.toml.md
@@ -20,12 +20,12 @@ Version must be dynamic and set once in code. `module.__about__` usually.
 
 ### Linting
 
-- Black (latest available version)
+- Ruff (latest available version)
 - Ruff for import sorting (isort-like) and many other checks
 - Dedicated hatch environment
-- Black and ruff configuration so those works without hatch as well
-- Scripts for just black and just ruff checking
-- Scripts for black fixing and ruf fixing (accepts params)
+- Ruff configuration so those works without hatch as well
+- Scripts for just ruff checking
+- Scripts for ruff fixing (accepts params)
 - Scripts for global checking and fixing
 - Sample ruff configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,8 @@ additional-keywords = ["some"]
 scripts = [
   "invoke==2.2.0",
 ]
-lint = [
-  "black==24.4.2",
-  "ruff==0.5.1",
-]
-check = [
+qa = [
+  "ruff==0.15.12",
   "pyright==1.1.370",
 ]
 test = [
@@ -34,9 +31,8 @@ dev = [
   "pre-commit==3.7.1",
   "debugpy==1.8.2",
   "great-project[scripts]",
-  "great-project[lint]",
+  "great-project[qa]",
   "great-project[test]",
-  "great-project[check]",
 ]
 
 [project.scripts]
@@ -69,29 +65,20 @@ report-cov = "inv report-cov"
 coverage = "inv coverage --args '{args}'"
 html = "inv coverage --html --args '{args}'"
 
-[tool.hatch.envs.lint]
-template = "lint"
+[tool.hatch.envs.qa]
+template = "qa"
 skip-install = false
-features = ["scripts", "lint"]
+features = ["scripts", "qa", "test"]
 
-[tool.hatch.envs.lint.scripts]
-black = "inv lint-black --args '{args}'"
-ruff = "inv lint-ruff --args '{args}'"
-all = "inv lintall --args '{args}'"
-fix-black = "inv fix-black --args '{args}'"
-fix-ruff = "inv fix-ruff --args '{args}'"
-fixall = "inv fixall --args '{args}'"
+[tool.hatch.envs.qa.scripts]
+check-lint = "inv check-lint --args '{args}'"
+check-format = "inv check-format --args '{args}'"
+check-type = "inv check-type --args '{args}'"
+check-all = "inv check-all --args '{args}'"
+fix-format = "inv fix-format --args '{args}'"
+fix-lint = "inv fix-lint --args '{args}'"
+fix-all = "inv fix-all --args '{args}'"
 
-[tool.hatch.envs.check]
-features = ["scripts", "check"]
-
-[tool.hatch.envs.check.scripts]
-pyright = "inv check-pyright --args '{args}'"
-all = "inv checkall --args '{args}'"
-
-[tool.black]
-line-length = 88
-target-version = ['py311']
 
 [tool.ruff]
 target-version = "py312"

--- a/tasks.py
+++ b/tasks.py
@@ -42,69 +42,65 @@ def coverage(ctx: Context, args: str = "", *, html: bool = False):
     report_cov(ctx, html=html)
 
 
-@task(optional=["args"], help={"args": "black additional arguments"})
-def lint_black(ctx: Context, args: str = "."):
-    args = args or "."  # needed for hatch script
-    ctx.run("black --version", pty=use_pty)
-    ctx.run(f"black --check --diff {args}", pty=use_pty)
-
-
-@task(optional=["args"], help={"args": "ruff additional arguments"})
-def lint_ruff(ctx: Context, args: str = "."):
+def _lint(ctx: Context, args: str = "."):
     args = args or "."  # needed for hatch script
     ctx.run("ruff --version", pty=use_pty)
     ctx.run(f"ruff check {args}", pty=use_pty)
 
 
-@task(
-    optional=["args"],
-    help={
-        "args": "linting tools (black, ruff) additional arguments, typically a path",
-    },
-)
-def lintall(ctx: Context, args: str = "."):
-    """Check linting"""
+@task(optional=["args"], help={"args": "ruff additional arguments"})
+def check_lint(ctx: Context, args: str = "."):
+    """check linting with ruff"""
     args = args or "."  # needed for hatch script
-    lint_black(ctx, args)
-    lint_ruff(ctx, args)
+    _lint(ctx, args)
+
+
+@task(optional=["args"], help={"args": "ruff additional arguments"})
+def fix_lint(ctx: Context, args: str = "."):
+    """fix linting issues with ruff"""
+    args = args or "."  # needed for hatch script
+    _lint(ctx, f"--fix {args}")
 
 
 @task(optional=["args"], help={"args": "check tools (pyright) additional arguments"})
-def check_pyright(ctx: Context, args: str = ""):
+def check_type(ctx: Context, args: str = ""):
     """check static types with pyright"""
     ctx.run("pyright --version")
     ctx.run(f"pyright {args}", pty=use_pty)
 
 
-@task(optional=["args"], help={"args": "check tools (pyright) additional arguments"})
-def checkall(ctx: Context, args: str = ""):
-    """check static types"""
-    check_pyright(ctx, args)
-
-
-@task(optional=["args"], help={"args": "black additional arguments"})
-def fix_black(ctx: Context, args: str = "."):
-    """fix black formatting"""
+def _format(ctx: Context, args: str = "."):
     args = args or "."  # needed for hatch script
-    ctx.run(f"black {args}", pty=use_pty)
+    ctx.run("ruff --version", pty=use_pty)
+    ctx.run(f"ruff format {args}", pty=use_pty)
 
 
 @task(optional=["args"], help={"args": "ruff additional arguments"})
-def fix_ruff(ctx: Context, args: str = "."):
-    """fix all ruff rules"""
+def check_format(ctx: Context, args: str = "."):
+    """check formatting with ruff"""
     args = args or "."  # needed for hatch script
-    ctx.run(f"ruff check --fix {args}", pty=use_pty)
+    _format(ctx, f"--check {args}")
 
 
-@task(
-    optional=["args"],
-    help={
-        "args": "linting tools (black, ruff) additional arguments, typically a path",
-    },
-)
-def fixall(ctx: Context, args: str = "."):
+@task(optional=["args"], help={"args": "ruff additional arguments"})
+def fix_format(ctx: Context, args: str = "."):
+    """fix formatting with ruff"""
+    args = args or "."  # needed for hatch script
+    _format(ctx, args)
+
+
+@task(optional=["args"], help={"args": "additional arguments"})
+def check_all(ctx: Context, args: str = ""):
+    """check linting, formatting and static types"""
+    args = args or "."  # needed for hatch script
+    check_lint(ctx, args)
+    check_format(ctx, args)
+    check_type(ctx, args)
+
+
+@task(optional=["args"], help={"args": "additional arguments"})
+def fix_all(ctx: Context, args: str = ""):
     """Fix everything automatically"""
     args = args or "."  # needed for hatch script
-    fix_black(ctx, args)
-    fix_ruff(ctx, args)
-    lintall(ctx, args)
+    fix_lint(ctx, args)
+    fix_format(ctx, args)


### PR DESCRIPTION
## Rationale

This PR removes black as a dev dependency due to conflicts between it and ruff. Accordingly, ruff is upgraded to the latest version (as of today).

## Changes
- remove `black` from `pyproject.toml`, `.pre-commit-config.yaml` and `tasks.py` and CI workflows
- upgrade `ruff` to `0.15.12`

This fixes #55 